### PR TITLE
Remove old ruby versions from Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: ruby
+cache: bundler
 rvm:
- - 1.8.7
- - 1.9.2
- - 1.9.3
+ - 2.2
+ - 2.3
  - ruby-head
  - jruby
- - ree
 
 before_install:
  - sudo apt-get update -qq


### PR DESCRIPTION
Support major ruby versions and enable bundler caching